### PR TITLE
プロファイル周りの挙動を修正

### DIFF
--- a/main.html
+++ b/main.html
@@ -82,7 +82,7 @@
                             <input type="password" class="form-control" id="settings_api_key">
                         </div>
                         <button class="btn-sm btn-primary w-100 btn-save mb-1" id="save_settings">Save Settings</button>
-                        <button class="btn-sm btn-danger w-100 btn-delete mb-1">Delete Profile</button>
+                        <button class="btn-sm btn-danger w-100 btn-delete mb-1" id="delete_settings">Delete Profile</button>
                     </div>
                 </div>
             </div>

--- a/main.js
+++ b/main.js
@@ -191,10 +191,16 @@ async function removeProfile() {
         profiles: saveSettings,
     };
     await chrome.storage.local.set(settings);
-    console.log('Misskey-Now: Stored New Settings.');
+    displayProfiles()
+    console.log('Misskey-Now: Stored Removed Settings.');
     settings_profile_name.value = '';
     settings_host.value = '';
     settings_api_key.value = '';
+    const prevText = delete_settings.textContent;
+    delete_settings.textContent = '✓';
+    setTimeout(() => {
+        delete_settings.textContent = prevText;
+    }, 1500);
 }
 
 // 子要素の削除

--- a/main.js
+++ b/main.js
@@ -177,6 +177,7 @@ function displayProfiles() {
     });
     if (typeof popup_profile.options[1] !== 'undefined') {
         popup_profile.options[1].setAttribute('selected', 'selected');
+        changeProfile()
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -175,8 +175,8 @@ function displayProfiles() {
         option.value = profile;
         popup_profile.appendChild(option);
     });
-    if(typeof popup_profile.options[1] !== 'undefined'){
-        popup_profile.options[1].setAttribute("selected", "selected")
+    if (typeof popup_profile.options[1] !== 'undefined') {
+        popup_profile.options[1].setAttribute('selected', 'selected');
     }
 }
 
@@ -191,7 +191,7 @@ async function removeProfile() {
         profiles: saveSettings,
     };
     await chrome.storage.local.set(settings);
-    displayProfiles()
+    displayProfiles();
     console.log('Misskey-Now: Stored Removed Settings.');
     settings_profile_name.value = '';
     settings_host.value = '';

--- a/main.js
+++ b/main.js
@@ -175,6 +175,9 @@ function displayProfiles() {
         option.value = profile;
         popup_profile.appendChild(option);
     });
+    if(typeof popup_profile.options[1] !== 'undefined'){
+        popup_profile.options[1].setAttribute("selected", "selected")
+    }
 }
 
 // プロファイルの削除


### PR DESCRIPTION
- プロファイルが存在するときは、保存されているプロファイルを最初から選択する
- removeProfile() が成功した際に、ボタンのテキストにチェックマークを表示する
- removeProfile() が実行されたあと、プロファイルの選択肢を更新する
- `setattribute` でプロファイルを変更すると、設定が更新されない問題を解決